### PR TITLE
[codex] Fix ALS parsing for generic annotations and group tracks

### DIFF
--- a/src/pyableton/Ableton.py
+++ b/src/pyableton/Ableton.py
@@ -1,5 +1,4 @@
 import gzip
-import os
 import xml.etree.ElementTree as ET
 
 import muspy
@@ -50,12 +49,12 @@ class Ableton(AbletonComponent):
             The path to the Ableton Live Set file (ALS) to be loaded.
         """
         self.als_file = als_file
-        filepath = "temp.xml"
-        self.to_xml(filepath)
-        tree = ET.parse(filepath)
-        os.remove(filepath)
-        root = tree.getroot()
+        root = self._load_root()
         super().__init__(root)
+
+    def _load_root(self):
+        with gzip.open(self.als_file, "rb") as gzipped_file:
+            return ET.fromstring(gzipped_file.read())
 
     def to_xml(self, filepath: str):
         """
@@ -66,8 +65,7 @@ class Ableton(AbletonComponent):
         filepath : str
             The path to save the XML file.
         """
-        with gzip.open(self.als_file, "rb") as gzipped_file:
-            xml_content = gzipped_file.read()
+        xml_content = ET.tostring(self._load_root())
         with open(filepath, "wb") as output_file:
             output_file.write(xml_content)
 

--- a/src/pyableton/AbletonComponent.py
+++ b/src/pyableton/AbletonComponent.py
@@ -1,4 +1,5 @@
 import json
+from typing import get_args, get_origin, get_type_hints
 from xml.etree import ElementTree
 
 
@@ -30,7 +31,9 @@ class AbletonComponent:
         root : ElementTree.Element
             The root element of the XML representation of the Ableton component.
         """
-        for annotation_param_name, annotation_param_type in self.__annotations__.items():
+        for annotation_param_name, annotation_param_type in get_type_hints(
+            self.__class__
+        ).items():
             initialized_value = self.init_python_object_from_annotation(
                 root, annotation_param_name, annotation_param_type
             )
@@ -64,14 +67,16 @@ class AbletonComponent:
         # we look in the nodes' children
 
         node = root.find(param_name)
+        origin = get_origin(annotation_param_type)
+        annotation_args = get_args(annotation_param_type)
 
         is_native_type = annotation_param_type in [int, str, float]
         is_bool = annotation_param_type == bool
         is_dict = annotation_param_type == dict
-        is_list_type = hasattr(annotation_param_type, "__origin__") and issubclass(
-            annotation_param_type.__origin__, list
+        is_list_type = origin is list
+        is_ableton_component = isinstance(annotation_param_type, type) and issubclass(
+            annotation_param_type, AbletonComponent
         )
-        is_ableton_component = issubclass(annotation_param_type, AbletonComponent)
 
         if is_native_type:
             new_param_value = list(node.attrib.values())[0]
@@ -83,10 +88,8 @@ class AbletonComponent:
             new_param_value = json.loads(list(node.attrib.values())[0])
 
         elif is_list_type:
-            ableton_component = annotation_param_type.__args__[0]
-            new_param_value = [
-                ableton_component(node) for node in root.find(param_name).findall("./")
-            ]
+            ableton_component = annotation_args[0]
+            new_param_value = [ableton_component(child) for child in node.findall("./")]
             annotation_param_type = list
 
         elif is_ableton_component:

--- a/src/pyableton/Midi.py
+++ b/src/pyableton/Midi.py
@@ -162,3 +162,20 @@ class DeviceChain(AbletonComponent):
     # signal_modulations: List[SignalModulation]
     # re_wire_slave_midi_target_id: ReWireSlaveMidiTargetId
     # pitchbend_range: PitchbendRange
+
+
+class GroupDeviceChain(AbletonComponent):
+    """
+    GroupDeviceChain Class
+
+    Represents a group-track device chain in Ableton Live.
+    Group tracks do not expose a MainSequencer node.
+    """
+
+    clip_envelope_chooser_view_state: ClipEnvelopeChooserViewState
+    audio_input_routing: IORouting
+    midi_input_routing: IORouting
+    audio_output_routing: IORouting
+    midi_output_routing: IORouting
+    mixer: Mixer
+    freeze_sequencer: FreezeSequencer

--- a/src/pyableton/Track.py
+++ b/src/pyableton/Track.py
@@ -1,7 +1,7 @@
 from xml.etree import ElementTree
 
 from .AbletonComponent import AbletonComponent
-from .Midi import DeviceChain, MidiName
+from .Midi import DeviceChain, GroupDeviceChain, MidiName
 
 
 class Track(AbletonComponent):
@@ -27,6 +27,8 @@ class Track(AbletonComponent):
                 return MidiTrack(track_node)
             elif track_node.tag == "AudioTrack":
                 return AudioTrack(track_node)
+            elif track_node.tag == "GroupTrack":
+                return GroupTrack(track_node)
             elif track_node.tag == "ReturnTrack":
                 return ReturnTrack(track_node)
             else:
@@ -218,6 +220,30 @@ class ReturnTrack(Track):
     # take_lanes: list[TakeLane]
     linked_track_group_id: int
     # device_chain: DeviceChain
+
+
+class GroupTrack(Track):
+    """
+    GroupTrack Class
+
+    Represents a group track in Ableton Live.
+    """
+
+    lom_id: int
+    lom_id_view: int
+    is_content_selected_in_document: bool
+    preferred_content_view_mode: int
+    track_delay: TrackDelay
+    name: MidiName
+    color: int
+    automation_envelopes: "AutomationEnvelopes"
+    track_group_id: int
+    track_unfolded: bool
+    devices_list_wrapper: int
+    clip_slots_list_wrapper: int
+    view_data: dict
+    linked_track_group_id: int
+    device_chain: GroupDeviceChain
 
 
 class TracksListWrapper(AbletonComponent):

--- a/test/test_ableton.py
+++ b/test/test_ableton.py
@@ -1,5 +1,7 @@
 import pathlib
 import unittest
+from unittest.mock import patch
+from xml.etree import ElementTree
 
 from pyableton.Ableton import Ableton
 from pyableton.AbletonComponent import AbletonComponent
@@ -8,7 +10,7 @@ from pyableton.LiveSet import LiveSet
 from pyableton.Midi import DeviceChain, IORouting, MidiName
 from pyableton.Mixer import Mixer
 from pyableton.Sequencer import FreezeSequencer, MainSequencer
-from pyableton.Track import MasterTrack, MidiTrack, Track, TrackDelay
+from pyableton.Track import GroupTrack, MasterTrack, MidiTrack, Track, TrackDelay
 
 
 class TestAbleton(unittest.TestCase):
@@ -153,3 +155,8 @@ class TestAbleton(unittest.TestCase):
 
     def test_midi_tracks(self):
         assert self.ableton.live_set.tracks[0] is not None
+
+    def test_group_track_factory(self):
+        with patch.object(GroupTrack, "__init__", return_value=None):
+            group_track = Track(ElementTree.fromstring("<GroupTrack />"))
+        assert isinstance(group_track, GroupTrack)


### PR DESCRIPTION
  ## Summary
  - fix annotation parsing to handle modern generic type hints on Python 3.13
  - parse `.als` files directly from gzip data instead of round-tripping through a shared `temp.xml`
  - add support for `GroupTrack` device chains that do not contain a `MainSequencer`

  ## Root Cause
  The parser assumed every annotation was a plain class and called `issubclass()` directly on parameterized generics like
  `list[Track]`, which raises `TypeError` on modern Python. It also assumed every track device chain exposed a `MainSequencer`, but
  Ableton group tracks instead nest another `DeviceChain` and omit that node.

  ## Impact
  This restores parsing for the existing test fixture on Python 3.13 and allows user-provided ALS files containing group tracks to
  load successfully.

  ## Validation
  - `pytest -q`
  - loaded `test/test.als`